### PR TITLE
Validation on Versions.bars == nil

### DIFF
--- a/modules/bars.lua
+++ b/modules/bars.lua
@@ -2044,7 +2044,7 @@ function module:OnInitialize()
 	local currentVersion = LUI.db.global.luiconfig[ProfileName].Versions.bars
 
 	-- recalc X/Y values for fixed scale options
-	if currentVersion < 2.4 then
+	if currentVersion == nil or currentVersion < 2.4 then
 		print("bla")
 		for k, v in pairs(module.db.profile) do
 			if type(v) == "table" then
@@ -2073,7 +2073,8 @@ function module:OnEnable()
 
 	--- This oen needed to be delayed until all addons are loaded.
 	local ProfileName = UnitName("player").." - "..GetRealmName()
-	if LUI.db.global.luiconfig[ProfileName].Versions.bars < LUI.Versions.bars then
+	local currentVersion = LUI.db.global.luiconfig[ProfileName].Versions.bars
+	if currentVersion == nil or currentVersion < LUI.Versions.bars then
 		module:AutoAdjustBT4("Right1")
 		module:AutoAdjustBT4("Right2")
 		module:AutoAdjustBT4("Left1")


### PR DESCRIPTION
There is an error on the current validation. If the LUI.db.global.luiconfig[ProfileName].Versions.bars is null, the comparison with numeric version results in error.
It's necessary to verify if the variable is null/nil before.
I've never programmed with lua, so, please, validate the code.

This is related with this issue: https://www.curseforge.com/wow/addons/lui/issues/453

Thanks.