### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--- Please read the FAQ and Wiki before creating a bug report. ---> 
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Error**
+If you received an error message please add it here.
+<!--- Paste your error between ``` and ```.  --->
+```
+
+```
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Versions (please complete the following information):**
+ - LUI version: [e.g. v3.33]
+ - World of Warcraft: [e.g. 9.0 Retail]
+
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Is your feature request related to a problem? Please describe.
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+Describe alternatives you've considered
+A clear and concise description of any alternative solutions or features you've considered.
+
+Additional context
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Adding a bug report template and feature request template. The Curseforge and Wowinterface pages should redirect here since no one keeps track of issues on those pages. Labels and bug tracking can be assigned and closed with commit messages.